### PR TITLE
ida 9.x support

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -13,17 +13,17 @@ struct SearchData
 	{
 		if (!buffer)
 		{
-			LOG_VERBOSE(__FUNCTION__ ": min_ea: 0x%llX, max_ea: 0x%llX, size: 0x%llX\n\n", (UINT64) inf.min_ea, (UINT64) inf.max_ea, (UINT64) (inf.max_ea - inf.min_ea));
+			LOG_VERBOSE(__FUNCTION__ ": min_ea: 0x%llX, max_ea: 0x%llX, size: 0x%llX\n\n", (UINT64) inf_get_min_ea(), (UINT64) inf_get_max_ea(), (UINT64) (inf_get_max_ea() - inf_get_min_ea()));
 
 			// Allocate page buffer to encompass the whole the IDB region
-			size = (UINT64) (inf.max_ea - inf.min_ea);
+			size = (UINT64) (inf_get_max_ea() - inf_get_min_ea());
 			buffer = (PBYTE) VirtualAlloc(NULL, size + 32, (MEM_COMMIT | MEM_RESERVE), PAGE_READWRITE);
 			if (buffer)
 			{
 				// Copy the IDB bytes to the buffer
 				// Simple loop much faster than: get_qword(), get_bytes(), etc.
 				// Note: For bytes that don't exist in the PE file, get_db_byte() will return 0xFF.
-				ea_t  currentEa = inf.min_ea;
+				ea_t  currentEa = inf_get_min_ea();
 				PBYTE ptr = buffer;
 				size_t count = size;
 

--- a/Signature.cpp
+++ b/Signature.cpp
@@ -95,7 +95,7 @@ void OutputSignature(const SIG &sig, ea_t address, UINT32 offset)
 static inline BOOL isJmpCntl(UINT32 type) { return((type >= NN_ja) && (type <= NN_jz)); }             // Return TRUE if a conditional jump instruction
 static inline BOOL isJmpNotCntl(UINT32 type) { return((type >= NN_jmp) && (type <= NN_jmpshort)); }   // Return TRUE if a non-conditional jump instruction
 static inline BOOL isCall(UINT32 type) { return((type >= NN_call) && (type <= NN_callni)); }          // Return TRUE if is a call instruction
-static inline BOOL IsIdbAddress(ea_t address) { return((address >= inf.min_ea) && (address < inf.max_ea)); }  // Returns TRUE if address is inside this IDB
+static inline BOOL IsIdbAddress(ea_t address) { return((address >= inf_get_min_ea()) && (address < inf_get_max_ea())); }  // Returns TRUE if address is inside this IDB
 
 // Return the instruction operand offset if it has one
 static UINT32 OperandOffset(__in insn_t &cmd)


### PR DESCRIPTION
`inf.min_ea` and `inf.max_ea` were replaced with `inf_get_min_ea()` and `inf_get_max_ea()` respectively.